### PR TITLE
refa: add basic tokenizer for booru sites

### DIFF
--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -9,6 +9,15 @@ export abstract class ImageSource<Config extends ImageSource.Config = ImageSourc
     this.ctx.booru.register(this)
   }
 
+  /**
+   * split query into tags, default implementation is comma-separated.
+   * 
+   * e.g. `tag1, wordy tag2, UPPER CASED tag3` => `['tag1', 'wordy_tag2', 'upper_cased_tag3']`
+   */
+  tokenize(query: string): string[] {
+    return query.split(',').map((x) => x.trim()).filter(Boolean).map((x) => x.toLowerCase().replace(/ +/g, '_'))
+  }
+
   abstract get(query: ImageSource.Query): Promise<ImageSource.Result[]>
 }
 

--- a/packages/lolicon/src/index.ts
+++ b/packages/lolicon/src/index.ts
@@ -9,6 +9,10 @@ class LoliconImageSource extends ImageSource<LoliconImageSource.Config> {
     super(ctx, config)
   }
 
+  override tokenize(query: string) {
+    return query.split(/\s+/)
+  }
+
   async get(query: ImageSource.Query): Promise<ImageSource.Result[]> {
     const proxy = typeof this.config.proxy === 'string' ? this.config.proxy : this.config.proxy?.endpoint
     const param: Lolicon.Request = {

--- a/packages/pixiv/src/index.ts
+++ b/packages/pixiv/src/index.ts
@@ -20,6 +20,10 @@ class PixivImageSource extends ImageSource<PixivImageSource.Config> {
     this.refreshToken = config.token
   }
 
+  override tokenize(query: string) {
+    return query.split(/\s+/)
+  }
+
   async get(query: ImageSource.Query): Promise<ImageSource.Result[]> {
     const url = '/v1/search/illust'
     const params: PixivAppApi.SearchParams = {


### PR DESCRIPTION
This is part of [Feature: Support searching for multiple tags #33](https://github.com/koishijs/koishi-plugin-booru/issues/33) changes, as the basic one for [Feature: add tokenizer for parsing tags for booru-series sites #34](https://github.com/koishijs/koishi-plugin-booru/issues/34)