### PR TITLE
ci: add publish actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        uses: koishijs/action-publish@master
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Publish
-        uses: koishijs/action-publish@master
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Set npm token
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish packages
+        run: |
+          yarn pub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,4 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish packages
-        run: |
-          yarn pub
+        run: yarn pub


### PR DESCRIPTION
~~The actual repository I've created is here: https://github.com/koishijs/action-publish~~

~~**Didn't test.**~~

~~Note:~~

~~- This workflow would install `yakumo` into global using `yarn global add` if `yakumo` command not found.~~
~~- This workflow didn't check the version diff before running `yakumo publish`, hope it would be automatically resolved by `yakumo`~~