### PR TITLE
chore: bump version to 5.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "^9.2.2",
     "sass": "^1.62.1",
     "shx": "^0.3.4",
-    "typescript": "^4.9.5",
+    "typescript": "^5.1.6",
     "vitepress": "1.0.0-alpha.73",
     "yakumo": "^0.3.10",
     "yakumo-esbuild": "^0.3.22",


### PR DESCRIPTION
This would fix the build error since schemastery upgraded