### PR TITLE
chore: add emitDeclarationOnly settings for typescript

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "emitDeclarationOnly": true,
     "moduleResolution": "bundler",
     "strictBindCallApply": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
This is the following fixup for #234 which switch TypeScript to ESNext module causing the result to be ESM, this setting would make `tsc` generates definitions only, and the JS part would be built by `esbuild` which guarantee to be CJS.